### PR TITLE
Upgrade to latest Qute and fix template to save BigDecimal boxing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<hbs.version>4.3.1</hbs.version>
 		<rocker.version>1.3.0</rocker.version>
 		<jte.version>2.3.0</jte.version>
-		<qute.version>2.16.4.Final</qute.version>
+		<qute.version>3.13.2</qute.version>
 	</properties>
 
 	<licenses>

--- a/src/main/java/com/mitchellbosecke/benchmark/Qute.java
+++ b/src/main/java/com/mitchellbosecke/benchmark/Qute.java
@@ -47,4 +47,14 @@ public class Qute extends BaseBenchmark {
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
+
+    public static void main(String[] args) {
+        Qute qute = new Qute();
+        try {
+            qute.setup();
+            System.out.println(qute.benchmark());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/resources/templates/stocks.qute.html
+++ b/src/main/resources/templates/stocks.qute.html
@@ -59,7 +59,7 @@ thead {
 				<td><a href="/stocks/{item.symbol}">{item.symbol}</a></td>
 				<td><a href="{item.url}">{item.name}</a></td>
 				<td><strong>{item.price}</strong></td>
-				{#if item.change < 0}
+				{#if item.change < 0d}
 				<td class="minus">{item.change}</td>
                 <td class="minus">{item.ratio}</td>
                 {#else}


### PR DESCRIPTION
@mkouba FYI

Similarly to what JTE and others does, Qute is using comparison features at runtime based on declared numeric types: `0` is not `0d` and they requires different, for the former in particular, comparison processing.

Said that; this benchmark is not super fair with Qute, because in Quarkus we will likely bytecode generate the field/method/getter accessors, instead of relying on reflection.
